### PR TITLE
fixed curve_type=instant 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ AS3 code to animate Spriter Animations.
 	var	atlas:TextureAtlas = mAssetManager.getTextureAtlas("player-atlas");		// load the texture atlas
 	var	xml:XML = mAssetManager.getXml("player");								// load the scml
 	var	name:String = "player";
+	var 	anim:String = "idle";
 
-	var	s:Spriter = new Spriter (name, xml, atlas);								// create an instance of a spriter animation
+	var	s:Spriter = new Spriter (name,anim, xml, atlas);								// create an instance of a spriter animation
 	s.play ("idle");
 	
-	addChild(s2);
-	Starling.juggler.add(s2);
+	addChild(s);
+	Starling.juggler.add(s);
 
 	

--- a/lib/com/acemobe/spriter/data/TimelineKey.as
+++ b/lib/com/acemobe/spriter/data/TimelineKey.as
@@ -78,11 +78,11 @@ package com.acemobe.spriter.data
 				c2 = timelineXml.@c2;
 			if (timelineXml.hasOwnProperty("@spin"))
 				spin = timelineXml.@spin;
-			if (timelineXml.hasOwnProperty("@curveType"))
+			if (timelineXml.hasOwnProperty("@curve_type"))
 			{
-				switch (timelineXml.@curveType)
+				switch (timelineXml.@curve_type.toString())
 				{
-					case	0:
+					case	"instant":
 						curveType = INSTANT;
 						break;
 				}


### PR DESCRIPTION
I use Spriter b6.1 and the xml is different than the parser and the reference (http://www.brashmonkey.com/ScmlDocs/ScmlReference.html)
Actually, it's curve_type="instant" in the xml and not curveType="0"
